### PR TITLE
Fix broken/missing symlink

### DIFF
--- a/recovery/root/init.recovery.mt6893.rc
+++ b/recovery/root/init.recovery.mt6893.rc
@@ -3,6 +3,8 @@ import /trustonic.rc
 
 on init
     export LD_LIBRARY_PATH /system/lib64:/vendor/lib64:/vendor/lib64/hw
+    # Create a more standard /dev/block layout for our scripts
+    symlink /dev/block/platform/bootdevice /dev/block/bootdevice
 
 on fs
     install_keyring


### PR DESCRIPTION
Some zips uses 
/dev/block/bootdevice/by-name 
By default we don't have this path so we symlink it